### PR TITLE
Issue/56/reflowing a layout

### DIFF
--- a/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/component/Component.scala
+++ b/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/component/Component.scala
@@ -17,3 +17,5 @@ trait Component[A]:
       context: UiContext[StartupData, ContextData],
       model: A
   ): Outcome[ComponentFragment]
+
+  def reflow(model: A): A

--- a/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/component/ComponentGroup.scala
+++ b/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/component/ComponentGroup.scala
@@ -58,7 +58,12 @@ final case class ComponentGroup(
 
   def reflow: ComponentGroup =
     val newComponents = components.foldLeft(Batch.empty[ComponentEntry[_]]) { (acc, entry) =>
-      acc :+ entry.copy(offset = nextOffset(acc))
+      val reflowed = entry.copy(
+        offset = nextOffset(acc),
+        model = entry.component.reflow(entry.model)
+      )
+
+      acc :+ reflowed
     }
 
     this.copy(components = newComponents)

--- a/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/component/ComponentGroup.scala
+++ b/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/component/ComponentGroup.scala
@@ -148,3 +148,11 @@ object ComponentGroup:
         model: ComponentGroup
     ): Outcome[ComponentFragment] =
       model.present(context)
+
+    def reflow(model: ComponentGroup): ComponentGroup =
+      val reflowed: Batch[ComponentEntry[?]] = model.components.map { c =>
+        c.copy(
+          model = c.component.reflow(c.model)
+        )
+      }
+      model.reflow.copy(components = reflowed)

--- a/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/component/ComponentGroup.scala
+++ b/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/component/ComponentGroup.scala
@@ -18,7 +18,7 @@ final case class ComponentGroup(
     def withPadding(p: Padding): Bounds =
       b.moveBy(p.left, p.top).resize(b.width + p.right, b.height + p.bottom)
 
-  private def nextOffset(components: Batch[ComponentEntry[_]]): Coords =
+  def nextOffset(components: Batch[ComponentEntry[_]]): Coords =
     layout match
       case ComponentLayout.None =>
         Coords.zero
@@ -45,7 +45,7 @@ final case class ComponentGroup(
             val maybeOffset = c.offset + Coords(padded.right, 0)
 
             if padded.moveBy(maybeOffset).right < bounds.width then maybeOffset
-            else Coords(0, maxY)
+            else Coords(padding.left, maxY)
           }
           .getOrElse(Coords(padding.left, padding.top))
 

--- a/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/components/Button.scala
+++ b/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/components/Button.scala
@@ -76,6 +76,9 @@ object Button:
         case ButtonState.Over => model.over.getOrElse(model.up)(context.bounds.coords, model.bounds)
         case ButtonState.Down => model.down.getOrElse(model.up)(context.bounds.coords, model.bounds)
 
+    def reflow(model: Button): Button =
+      model
+
 enum ButtonState:
   case Up, Over, Down
 

--- a/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/components/Label.scala
+++ b/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/components/Label.scala
@@ -34,3 +34,6 @@ object Label:
         model: Label
     ): Outcome[ComponentFragment] =
       model.render(context.bounds.coords, model.text)
+
+    def reflow(model: Label): Label =
+      model

--- a/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/window/Window.scala
+++ b/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/window/Window.scala
@@ -35,7 +35,7 @@ object Window:
     case WindowEvent.ResizeBy(id, dragData) if model.id == id =>
       Outcome(
         model.withDimensions(model.bounds.dimensions + (dragData.by - dragData.offset).toDimensions)
-      )
+      ).addGlobalEvents(WindowEvent.Resized(id))
 
     case e =>
       val b = model.bounds

--- a/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/window/WindowEvent.scala
+++ b/roguelike-starterkit/src/main/scala/roguelikestarterkit/ui/window/WindowEvent.scala
@@ -7,6 +7,7 @@ enum WindowEvent extends GlobalEvent:
   case MoveBy(id: WindowId, dragData: DragData)
   case MoveTo(id: WindowId, position: Coords)
   case ResizeBy(id: WindowId, dragData: DragData)
+  case Resized(id: WindowId)
   case Redraw
   case ClearData
   case MouseOver(id: WindowId)

--- a/roguelike-starterkit/src/test/scala/roguelikestarterkit/ui/component/ComponentGroupTests.scala
+++ b/roguelike-starterkit/src/test/scala/roguelikestarterkit/ui/component/ComponentGroupTests.scala
@@ -1,7 +1,10 @@
 package roguelikestarterkit.ui.component
 
 import indigo.*
-import roguelikestarterkit.*
+import roguelikestarterkit.Bounds
+import roguelikestarterkit.Coords
+import roguelikestarterkit.UiContext
+import roguelikestarterkit.ui.component.ComponentLayout.Horizontal
 
 class ComponentGroupTests extends munit.FunSuite {
 
@@ -39,6 +42,159 @@ class ComponentGroupTests extends munit.FunSuite {
       List(
         Coords(5, 5),
         Coords(18, 5) // It's like this: 5 |3| 5.5 |3| 5
+      )
+
+    assertEquals(actual, expected)
+  }
+
+  test("Calculate the next offset - vertical, padding 0") {
+    val group = ComponentGroup(Bounds(0, 0, 10, 5))
+      .withLayout(ComponentLayout.Vertical(Padding(0)))
+      .add("abc", "def")
+
+    val actual =
+      group.components.map(_.offset).toList
+
+    val expected =
+      List(
+        Coords(0, 0),
+        Coords(0, 1)
+      )
+
+    assertEquals(actual, expected)
+  }
+
+  test("Calculate the next offset - vertical, padding 5") {
+    val group = ComponentGroup(Bounds(0, 0, 10, 5))
+      .withLayout(ComponentLayout.Vertical(Padding(5)))
+      .add("abc", "def")
+
+    val actual =
+      group.components.map(_.offset).toList
+
+    val expected =
+      List(
+        Coords(5, 5),
+        Coords(5, 5 + 1 + 5 + 5)
+      )
+
+    assertEquals(actual, expected)
+  }
+
+  test("Calculate the next offset - vertical, padding top=5") {
+    val group = ComponentGroup(Bounds(0, 0, 10, 5))
+      .withLayout(ComponentLayout.Vertical(Padding(5, 0, 0, 0)))
+      .add("abc", "def")
+
+    val actual =
+      group.components.map(_.offset).toList
+
+    val expected =
+      List(
+        Coords(0, 5),
+        Coords(0, 5 + 1 + 5)
+      )
+
+    assertEquals(actual, expected)
+  }
+
+  test("Calculate the next offset - horizontal, padding 0, hidden") {
+    val group = ComponentGroup(Bounds(0, 0, 5, 5))
+      .withLayout(ComponentLayout.Horizontal(Padding(0), Overflow.Hidden))
+      .add("abc", "def")
+
+    val actual =
+      group.components.map(_.offset).toList
+
+    val expected =
+      List(
+        Coords(0, 0),
+        Coords(3, 0)
+      )
+
+    assertEquals(actual, expected)
+  }
+
+  test("Calculate the next offset - horizontal, padding 5, hidden") {
+    val group = ComponentGroup(Bounds(0, 0, 5, 5))
+      .withLayout(ComponentLayout.Horizontal(Padding(5), Overflow.Hidden))
+      .add("abc", "def")
+
+    val actual =
+      group.components.map(_.offset).toList
+
+    val expected =
+      List(
+        Coords(5, 5),
+        Coords(5 + 3 + 5 + 5, 5)
+      )
+
+    assertEquals(actual, expected)
+  }
+
+  test("Calculate the next offset - horizontal, padding left=5, hidden") {
+    val group = ComponentGroup(Bounds(0, 0, 5, 5))
+      .withLayout(ComponentLayout.Horizontal(Padding(0, 0, 0, 5), Overflow.Hidden))
+      .add("abc", "def")
+
+    val actual =
+      group.components.map(_.offset).toList
+
+    val expected =
+      List(
+        Coords(5, 0),
+        Coords(5 + 3 + 5, 0)
+      )
+
+    assertEquals(actual, expected)
+  }
+
+  test("Calculate the next offset - horizontal, padding 0, wrap") {
+    val group = ComponentGroup(Bounds(0, 0, 5, 5))
+      .withLayout(ComponentLayout.Horizontal(Padding(0), Overflow.Wrap))
+      .add("abc", "def")
+
+    val actual =
+      group.components.map(_.offset).toList
+
+    val expected =
+      List(
+        Coords(0, 0),
+        Coords(0, 1)
+      )
+
+    assertEquals(actual, expected)
+  }
+
+  test("Calculate the next offset - horizontal, padding 5, wrap") {
+    val group = ComponentGroup(Bounds(0, 0, 5, 5))
+      .withLayout(ComponentLayout.Horizontal(Padding(5), Overflow.Wrap))
+      .add("abc", "def")
+
+    val actual =
+      group.components.map(_.offset).toList
+
+    val expected =
+      List(
+        Coords(5, 5),
+        Coords(5, 5 + 1 + 5)
+      )
+
+    assertEquals(actual, expected)
+  }
+
+  test("Calculate the next offset - horizontal, padding left=5 top=2, wrap") {
+    val group = ComponentGroup(Bounds(0, 0, 3, 5))
+      .withLayout(ComponentLayout.Horizontal(Padding(2, 0, 0, 5), Overflow.Wrap))
+      .add("abc", "def")
+
+    val actual =
+      group.components.map(_.offset).toList
+
+    val expected =
+      List(
+        Coords(5, 2),
+        Coords(5, 2 + 1)
       )
 
     assertEquals(actual, expected)

--- a/roguelike-starterkit/src/test/scala/roguelikestarterkit/ui/component/ComponentGroupTests.scala
+++ b/roguelike-starterkit/src/test/scala/roguelikestarterkit/ui/component/ComponentGroupTests.scala
@@ -19,6 +19,9 @@ class ComponentGroupTests extends munit.FunSuite {
         model: String
     ): Outcome[ComponentFragment] =
       Outcome(ComponentFragment.empty)
+
+    def reflow(model: String): String =
+      model
   }
 
   test("reflow should reapply the layout to all existing components") {

--- a/roguelike-starterkit/src/test/scala/roguelikestarterkit/ui/component/ComponentGroupTests.scala
+++ b/roguelike-starterkit/src/test/scala/roguelikestarterkit/ui/component/ComponentGroupTests.scala
@@ -1,0 +1,43 @@
+package roguelikestarterkit.ui.component
+
+import indigo.*
+import roguelikestarterkit.*
+
+class ComponentGroupTests extends munit.FunSuite {
+
+  given Component[String] = new Component[String] {
+    def bounds(model: String): Bounds = Bounds(0, 0, model.length, 1)
+
+    def updateModel[StartupData, ContextData](
+        context: UiContext[StartupData, ContextData],
+        model: String
+    ): GlobalEvent => Outcome[String] =
+      _ => Outcome(model)
+
+    def present[StartupData, ContextData](
+        context: UiContext[StartupData, ContextData],
+        model: String
+    ): Outcome[ComponentFragment] =
+      Outcome(ComponentFragment.empty)
+  }
+
+  test("reflow should reapply the layout to all existing components") {
+    val component1 = ComponentEntry(Coords(0, 0), "abc", summon[Component[String]])
+    val component2 = ComponentEntry(Coords(10, 10), "def", summon[Component[String]])
+    val group = ComponentGroup(
+      Bounds(0, 0, 100, 100),
+      ComponentLayout.Horizontal(Padding(5), Overflow.Wrap),
+      Batch(component1, component2)
+    )
+
+    val actual = group.reflow.components.toList.map(_.offset)
+
+    val expected =
+      List(
+        Coords(5, 5),
+        Coords(18, 5) // It's like this: 5 |3| 5.5 |3| 5
+      )
+
+    assertEquals(actual, expected)
+  }
+}


### PR DESCRIPTION
Relates to #56. 

Provides a `reflow` operation on a component group, which is propagated to sub-components.

When called, the operation re-applies the layout given the current bounds. This works, but in fact has limited usefulness without https://github.com/PurpleKingdomGames/roguelike-starterkit/issues/70.

Additionally, there is a new `WindowEvent.Resized` event you can listen for in order to respond when a window has finished resizing.

Taken the opportunity to add more tests around the offset calculation.